### PR TITLE
Type checking the input for prime computation

### DIFF
--- a/isitprime.html
+++ b/isitprime.html
@@ -132,6 +132,9 @@
       }
       
       function prime(input){
+        if(typeof input !== 'number') {
+          return false;
+        }
         var foundprime=true;
         var allfactors=[];
         var input2=input;


### PR DESCRIPTION
**Issue:** I noticed that the "Is it prime" application was returning incorrect inputs for strings and real numbers. 

**Fix:** Adding a type check on the `input` prior to performing any calculations.